### PR TITLE
코드 리팩토링 2차 피드백 적용(id값을 thread-safe, slf4j)

### DIFF
--- a/src/main/java/com/youngseo3/hospitalappointmentsystem/controller/ReservationController.java
+++ b/src/main/java/com/youngseo3/hospitalappointmentsystem/controller/ReservationController.java
@@ -11,9 +11,9 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-@RestController
-@RequestMapping("/reservations")
 @RequiredArgsConstructor
+@RequestMapping("/reservations")
+@RestController
 public class ReservationController {
     private final ReservationService reservationService;
 

--- a/src/main/java/com/youngseo3/hospitalappointmentsystem/entity/Reservation.java
+++ b/src/main/java/com/youngseo3/hospitalappointmentsystem/entity/Reservation.java
@@ -2,7 +2,6 @@ package com.youngseo3.hospitalappointmentsystem.entity;
 
 import lombok.Getter;
 import lombok.Setter;
-
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 
@@ -27,11 +26,6 @@ public class Reservation {
     public boolean isEqualsReservationTime(Reservation other) {
         return reservationTime.equals(other.getReservationTime());
     }
-
-    public boolean isEqualsId(Long id) {
-        return this.id.equals(id);
-    }
-
 
     private void validateReservationTime(LocalDateTime reservationTime) {
         LocalTime time = reservationTime.toLocalTime();

--- a/src/main/java/com/youngseo3/hospitalappointmentsystem/repository/ReservationRepository.java
+++ b/src/main/java/com/youngseo3/hospitalappointmentsystem/repository/ReservationRepository.java
@@ -20,7 +20,7 @@ public class ReservationRepository {
 
     public Reservation findById(Long id) {
         for (Reservation reservation: reservations) {
-            if (reservation.isEqualsId(id)) {
+            if (reservation.getId().equals(id)) {
                 return reservation;
             }
         }

--- a/src/main/java/com/youngseo3/hospitalappointmentsystem/repository/ReservationRepository.java
+++ b/src/main/java/com/youngseo3/hospitalappointmentsystem/repository/ReservationRepository.java
@@ -6,8 +6,8 @@ import org.springframework.stereotype.Repository;
 
 import java.util.List;
 
-@Repository
 @RequiredArgsConstructor
+@Repository
 public class ReservationRepository {
     private final List<Reservation> reservations;
     private Long id = 1L;

--- a/src/main/java/com/youngseo3/hospitalappointmentsystem/repository/ReservationRepository.java
+++ b/src/main/java/com/youngseo3/hospitalappointmentsystem/repository/ReservationRepository.java
@@ -12,7 +12,7 @@ public class ReservationRepository {
     private final List<Reservation> reservations;
     private Long id = 1L;
 
-    public void save(Reservation reservation) {
+    public synchronized void save(Reservation reservation) {
         isTimeOverlapping(reservation);
         reservation.setId(id++);
         reservations.add(reservation);
@@ -38,5 +38,9 @@ public class ReservationRepository {
                 throw new IllegalArgumentException("해당 시간에는 이미 예약이 있습니다. 다른 시간을 선택해주세요.");
             }
         }
+    }
+
+    public List<Reservation> findAll() {
+        return reservations;
     }
 }

--- a/src/main/java/com/youngseo3/hospitalappointmentsystem/service/ReservationService.java
+++ b/src/main/java/com/youngseo3/hospitalappointmentsystem/service/ReservationService.java
@@ -7,10 +7,12 @@ import com.youngseo3.hospitalappointmentsystem.dto.ReservationDeleteResponse;
 import com.youngseo3.hospitalappointmentsystem.entity.Reservation;
 import com.youngseo3.hospitalappointmentsystem.repository.ReservationRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
-@Service
 @RequiredArgsConstructor
+@Slf4j
+@Service
 public class ReservationService {
     private final ReservationRepository reservationRepository;
 
@@ -25,7 +27,7 @@ public class ReservationService {
         Reservation reservation = reservationRepository.findById(reservationId);
         reservationRepository.delete(reservation);
 
-        System.out.println(request.getCancelReason());
+        log.info("예약 취소 사유: {}", request.getCancelReason());
 
         return ReservationDeleteResponse.success();
     }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,2 @@
 spring.application.name=Hospital-Appointment-System
+logging.level.root=debug

--- a/src/test/java/com/youngseo3/hospitalappointmentsystem/HospitalAppointmentSystemApplicationTests.java
+++ b/src/test/java/com/youngseo3/hospitalappointmentsystem/HospitalAppointmentSystemApplicationTests.java
@@ -5,9 +5,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 
 @SpringBootTest
 class HospitalAppointmentSystemApplicationTests {
-
     @Test
     void contextLoads() {
     }
-
 }

--- a/src/test/java/com/youngseo3/hospitalappointmentsystem/ReservationConcurrencyTest.java
+++ b/src/test/java/com/youngseo3/hospitalappointmentsystem/ReservationConcurrencyTest.java
@@ -1,0 +1,95 @@
+package com.youngseo3.hospitalappointmentsystem;
+
+import com.youngseo3.hospitalappointmentsystem.entity.Reservation;
+import com.youngseo3.hospitalappointmentsystem.repository.ReservationRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+class ReservationConcurrencyTest {
+
+    @Autowired
+    private ReservationRepository reservationRepository;
+    private List<Reservation> savedReservations;
+    private static final int THREAD_COUNT = 100;
+
+    @BeforeEach
+    void 각각의_테스트를_하기_전에_THREAD_COUNT만큼_쓰레드가_동시에_예약한다() throws InterruptedException {
+        ExecutorService executorService = Executors.newFixedThreadPool(32);
+        CountDownLatch latch = new CountDownLatch(THREAD_COUNT);
+        LocalDate baseDate = LocalDate.of(2025, 11, 10);
+
+        for (int i = 1; i <= THREAD_COUNT; i++) {
+            int thread = i;
+            executorService.submit(() -> {
+                try {
+                    int dayOffset = thread / 9;
+                    int hourOffset = thread % 9;
+
+                    Long doctorId = 1L;
+                    LocalDateTime reservationTime = LocalDateTime.of(
+                            baseDate.plusDays(dayOffset),
+                            LocalTime.of(9 + hourOffset, 0)
+                    );
+
+                    Reservation reservation = new Reservation(
+                            (long) (thread % THREAD_COUNT),
+                            doctorId,
+                            reservationTime,
+                            "증상 " + thread
+                    );
+
+                    reservationRepository.save(reservation);
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+
+        latch.await();
+        executorService.shutdown();
+
+        // 저장된 예약 조회
+        savedReservations = reservationRepository.findAll();
+    }
+
+    @Test
+    void 예약은_THREAD_COUNT_만큼_모두_저장되어야_한다() {
+        assertThat(savedReservations).hasSize(THREAD_COUNT);
+    }
+
+    @Test
+    void 예약_생성_시_id_중복이_발생하지_않아야_한다() {
+        Set<Long> ids = savedReservations.stream()
+                .map(Reservation::getId)
+                .collect(Collectors.toSet());
+
+        assertThat(ids).hasSize(THREAD_COUNT);
+    }
+
+    @Test
+    void ID는_1씩_순차적으로_증가해야_한다() {
+        List<Long> sortedIds = savedReservations.stream()
+                .map(Reservation::getId)
+                .sorted()
+                .toList();
+
+        for (int i = 0; i < THREAD_COUNT; i++) {
+            assertThat(sortedIds.get(i)).isEqualTo((long) (i + 1));
+        }
+    }
+}


### PR DESCRIPTION
- 코드 포맷팅
- ReservationRepository의 id를 thread-safe하도록 리팩토링
    - 100개의 쓰레드가 예약 생성을 할 때 id 값이나, 예약이 올바르게 생성되는지 동시성 테스트도 완료
- System.out.println으로 로그를 남긴 방식 -> slf4j로 리팩토링
- Reservation에 isEqualsId 메서드 삭제